### PR TITLE
define bugfix

### DIFF
--- a/src/sanity/improvements.clj
+++ b/src/sanity/improvements.clj
@@ -57,7 +57,7 @@
           (core-let [s (seq coll)]
             (if s
               (if (chunked-seq? s)
-                (recur f 
+                (recur f
                        (.reduce (chunk-first s) f val)
                        (chunk-next s))
                 (recur f (f val (first s)) (next s)))
@@ -109,9 +109,9 @@
        (list (with-meta head {:dynamic true}))
        (list head)))
    ~@(if (and (seq? head) (string? docstring?))
-      body
+      (if (empty? body) (list docstring?) body)
       (cons docstring? body))))
- 
+
 (defmacro conds
  "A variant of cond with sane (lisp/scheme) bracketing. Unfortunately there's
   no way to detect if we want the clojure cond or the sane cond so we have to
@@ -188,7 +188,7 @@
                     ((empty? l) c)
                     ((p (first l)) (recur (rest l) (+ c 1)))
                     (else (recur (rest l) c))))))
-          
+
           (defn every? [p l & ls]
            "Is p true of every element of the collection(s) l(s)?"
            (sanity.improvements/core-loop [l l ls ls]


### PR DESCRIPTION
Dear Sir/Madam,

Due to docstring handling, (define (hello) "some docs" 2) works, but (define (hello) "string") doesn't, because the macro assumes that if there's a docstring, then there's definitely a body.

